### PR TITLE
Add multithreaded Flask core

### DIFF
--- a/context_memory.py
+++ b/context_memory.py
@@ -33,6 +33,10 @@ class ContextMemory:
         """Return the most recent events from short-term memory."""
         return list(self.short_term)[-limit:]
 
+    def get_recent_context(self) -> List[Dict[str, str]]:
+        """Alias for ``recent_events`` for API convenience."""
+        return self.recent_events()
+
     # Long-term memory ------------------------------------------------------
     def remember(self, key: str, value: str) -> None:
         """Persist a key/value pair for long-term recall."""

--- a/krator/krator_core.py
+++ b/krator/krator_core.py
@@ -1,69 +1,177 @@
-"""Main task engine and module router."""
+"""Multithreaded Flask-based API core for the Krator assistant."""
 
 from __future__ import annotations
+import base64
 import logging
-from typing import Optional
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
 
-from .modules.presence_detector import PresenceDetector
-from .modules.project_manager import ProjectManager
-from .modules.voice_interface import VoiceInterface
-from .modules.context_memory import ContextMemory
-from .modules.device_bridge import DeviceBridge
-from .modules.security_layer import SecurityLayer
-from .modules.automation_engine import AutomationEngine
-from .modules.vision_module import VisionModule
+from flask import Flask, jsonify, request
+import cv2
+
+# Import modules from top-level package wrappers
+from modules.voice_interface import VoiceInterface
+from modules.vision_module import VisionModule
+from modules.context_memory import ContextMemory
+from modules.project_manager import ProjectManager
+
+LOG_PATH = os.path.join("data", "logs", "krator.log")
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[logging.FileHandler(LOG_PATH), logging.StreamHandler()],
+)
 
 
 class KratorCore:
-    """Central orchestrator for Krator."""
+    """Core coordinator exposing a Flask API and running module threads."""
 
     def __init__(self) -> None:
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.presence = PresenceDetector()
-        self.project_manager = ProjectManager()
         self.voice = VoiceInterface()
+        try:
+            self.vision: Optional[VisionModule] = VisionModule()
+        except Exception as exc:  # pragma: no cover - hardware dependent
+            self.logger.warning("Vision module unavailable: %s", exc)
+            self.vision = None
         self.memory = ContextMemory()
-        self.devices = DeviceBridge()
-        self.security = SecurityLayer()
-        self.automation = AutomationEngine()
-        self.vision: Optional[VisionModule] = None
+        self.projects = ProjectManager()
         self.running = False
+        self.threads: list[threading.Thread] = []
 
-    def start(self) -> None:
-        """Initialize modules and greet the user."""
-        self.logger.info("Starting KratorCore")
+        self.app = Flask(__name__)
+        self._register_routes()
+
+    # ------------------------------------------------------------------
+    def _register_routes(self) -> None:
+        """Configure Flask route handlers."""
+
+        @self.app.post("/voice/input")
+        def voice_input() -> Any:
+            """Process a text command via the voice interface."""
+            data = request.get_json(silent=True) or {}
+            text = str(data.get("text", ""))
+            try:
+                response = self.voice.process_command(text)
+                return jsonify({"response": response})
+            except Exception as exc:  # pragma: no cover - runtime protection
+                self.logger.exception("Voice processing failed")
+                return jsonify({"error": str(exc)}), 500
+
+        @self.app.get("/vision/snapshot")
+        def vision_snapshot() -> Any:
+            """Return a base64 encoded snapshot from the vision module."""
+            if not self.vision:
+                return jsonify({"error": "vision unavailable"}), 503
+            frame = self.vision.get_current_frame()
+            if frame is None:
+                return jsonify({"error": "no frame"}), 500
+            ret, buf = cv2.imencode(".jpg", frame)
+            if not ret:
+                return jsonify({"error": "encoding failed"}), 500
+            b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+            return jsonify({"image": b64})
+
+        @self.app.get("/memory/context")
+        def memory_context() -> Any:
+            """Return recent context memory."""
+            return jsonify(self.memory.get_recent_context())
+
+        @self.app.post("/project/task")
+        def project_task() -> Any:
+            """Add or update a task via the project manager."""
+            data = request.get_json(silent=True) or {}
+            try:
+                self.projects.add_or_update_task(data)
+                return jsonify({"status": "ok"})
+            except Exception as exc:  # pragma: no cover - runtime protection
+                self.logger.exception("Project manager error")
+                return jsonify({"error": str(exc)}), 500
+
+        @self.app.get("/status/modules")
+        def status_modules() -> Any:
+            """Report operational status of all modules."""
+            status: Dict[str, Any] = {
+                "voice": self.voice.recognizer is not None,
+                "vision": bool(self.vision and self.vision.capture),
+                "memory": True,
+                "projects": True,
+            }
+            return jsonify(status)
+
+    # ------------------------------------------------------------------
+    def _start_threads(self) -> None:
+        """Spawn daemon threads for long-running modules."""
+        self.logger.info("Starting module threads")
+        loops = [
+            threading.Thread(target=self._voice_loop, daemon=True),
+            threading.Thread(target=self._vision_loop, daemon=True),
+            threading.Thread(target=self._memory_loop, daemon=True),
+            threading.Thread(target=self._project_loop, daemon=True),
+        ]
+        for thread in loops:
+            thread.start()
+            self.threads.append(thread)
+
+    # ------------------------------------------------------------------
+    def _voice_loop(self) -> None:
+        """Continuously listen for voice commands."""
+        while self.running:
+            if not self.voice.recognizer:
+                time.sleep(1)
+                continue
+            try:
+                text = self.voice.listen()
+                if text:
+                    self.memory.add_event("voice", text)
+                    self.voice.process_command(text)
+            except Exception as exc:  # pragma: no cover - runtime protection
+                self.logger.error("Voice loop error: %s", exc)
+
+    def _vision_loop(self) -> None:
+        """Capture frames for context when the camera is available."""
+        if not self.vision:
+            return
+        while self.running:
+            try:
+                frame = self.vision.read_frame()
+                if frame is not None:
+                    self.memory.add_event("vision", "frame")
+                else:
+                    time.sleep(0.5)
+            except Exception as exc:  # pragma: no cover - runtime protection
+                self.logger.error("Vision loop error: %s", exc)
+                break
+
+    def _memory_loop(self) -> None:
+        """Periodic housekeeping for memory management."""
+        while self.running:
+            time.sleep(60)
+
+    def _project_loop(self) -> None:
+        """Placeholder project manager loop."""
+        while self.running:
+            time.sleep(60)
+
+    # ------------------------------------------------------------------
+    def start(self, host: str = "0.0.0.0", port: int = 8000) -> None:
+        """Start all threads and run the Flask server."""
+        self.logger.info("KratorCore starting")
         self.running = True
-        if self.presence.is_user_nearby():
-            self.voice.speak("Krator online and ready")
+        self._start_threads()
+        self.app.run(host=host, port=port, threaded=True)
 
     def stop(self) -> None:
-        """Shutdown modules."""
-        self.logger.info("Stopping KratorCore")
+        """Signal all threads to stop."""
+        self.logger.info("KratorCore stopping")
         self.running = False
         if self.vision:
             self.vision.close()
 
-    def handle_command(self, text: str) -> None:
-        """Basic command handler."""
-        text = text.strip()
-        if not text:
-            return
-        self.logger.info("Handling command: %s", text)
-        self.memory.add_event("command", text)
-        if text.lower() == "status":
-            self.voice.speak("System nominal")
-        elif text.lower().startswith("send "):
-            _, device_id, command = text.split(maxsplit=2)
-            self.devices.send_command(device_id, command)
 
-    def run_forever(self) -> None:
-        """Run a simple command loop."""
-        self.start()
-        try:
-            while self.running:
-                text = self.voice.listen() if self.voice.recognizer else input("> ")
-                if text.lower() in {"quit", "exit"}:
-                    break
-                self.handle_command(text)
-        finally:
-            self.stop()
+if __name__ == "__main__":
+    core = KratorCore()
+    core.start()

--- a/modules/context_memory.py
+++ b/modules/context_memory.py
@@ -1,0 +1,2 @@
+from context_memory import ContextMemory
+__all__ = ["ContextMemory"]

--- a/modules/project_manager.py
+++ b/modules/project_manager.py
@@ -1,0 +1,2 @@
+from project_manager import ProjectManager
+__all__ = ["ProjectManager"]

--- a/modules/vision_module.py
+++ b/modules/vision_module.py
@@ -1,0 +1,2 @@
+from vision_module import VisionModule
+__all__ = ["VisionModule"]

--- a/modules/voice_interface.py
+++ b/modules/voice_interface.py
@@ -1,0 +1,2 @@
+from voice_interface import VoiceInterface
+__all__ = ["VoiceInterface"]

--- a/project_manager.py
+++ b/project_manager.py
@@ -19,3 +19,10 @@ class ProjectManager:
         """Update a task with new notes or status."""
         # TODO: implement update logic via the chosen API
         pass
+
+    def add_or_update_task(self, task: dict) -> None:
+        """Create or update a task using provided data."""
+        tid = task.get("id")
+        notes = task.get("notes", "")
+        if tid:
+            self.update_task(tid, notes)

--- a/vision_module.py
+++ b/vision_module.py
@@ -27,3 +27,12 @@ class VisionModule:
         if self.capture is not None:
             self.capture.release()
             self.capture = None
+
+    def get_current_frame(self):
+        """Return the latest frame, opening the camera if needed."""
+        if self.capture is None:
+            try:
+                self.open()
+            except Exception:
+                return None
+        return self.read_frame()

--- a/voice_interface.py
+++ b/voice_interface.py
@@ -30,3 +30,10 @@ class VoiceInterface:
         if self.engine:
             self.engine.say(text)
             self.engine.runAndWait()
+
+    def process_command(self, text: str) -> str:
+        """Handle a voice command and return a response string."""
+        if not text:
+            return ""
+        self.speak(text)
+        return f"Processed: {text}"


### PR DESCRIPTION
## Summary
- create package `modules` exporting main components
- extend helper modules with new APIs
- rewrite `krator_core` with Flask server and background threads
- provide stub `process_command` and project task handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f1801a0748328b8e8e9cd1b90229e